### PR TITLE
Update CI checkout version and other refactoring

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Git checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
 
       - name: Run tests on PHP ${{ matrix.php-version }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+.idea/
 /vendor/
+
 .php_cs.cache
 .phpunit.cache
 .phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 .idea/
 /vendor/
 
-.php_cs.cache
-.phpunit.cache
-.phpunit.result.cache
+*.cache

--- a/src/Encoder/PaymentRequestDecoder.php
+++ b/src/Encoder/PaymentRequestDecoder.php
@@ -13,9 +13,6 @@ declare(strict_types=1);
 
 namespace Jorijn\Bitcoin\Bolt11\Encoder;
 
-use function BitWasp\Bech32\decodeRaw;
-use function BitWasp\Bech32\encode;
-
 use BitWasp\Bitcoin\Address\PayToPubKeyHashAddress;
 use BitWasp\Bitcoin\Address\ScriptHashAddress;
 use BitWasp\Bitcoin\Address\SegwitAddress;
@@ -39,6 +36,9 @@ use Jorijn\Bitcoin\Bolt11\Exception\UnableToDecodeBech32Exception;
 use Jorijn\Bitcoin\Bolt11\Exception\UnknownFallbackAddressVersionException;
 use Jorijn\Bitcoin\Bolt11\Exception\UnknownNetworkVersionException;
 use Jorijn\Bitcoin\Bolt11\Exception\UnrecoverableSignatureException;
+
+use function BitWasp\Bech32\decodeRaw;
+use function BitWasp\Bech32\encode;
 
 /**
  * This class decodes BOLT11 payment requests into plain PHP array data.
@@ -76,15 +76,14 @@ class PaymentRequestDecoder
     ];
 
     /** @var string[] */
-    protected $tagNames = [];
+    private array $tagNames;
 
     /** @var \Closure[] */
-    protected $tagParsers = [];
+    private array $tagParsers = [];
 
-    /** @var EcAdapterInterface */
-    protected $ecAdapter;
+    private EcAdapterInterface $ecAdapter;
 
-    public function __construct(EcAdapterInterface $ecAdapter = null)
+    public function __construct(?EcAdapterInterface $ecAdapter = null)
     {
         $this->ecAdapter = $ecAdapter ?? Bitcoin::getEcAdapter();
         $this->tagNames = array_flip(self::TAG_CODES);

--- a/src/Normalizer/PaymentRequestDenormalizer.php
+++ b/src/Normalizer/PaymentRequestDenormalizer.php
@@ -23,7 +23,7 @@ class PaymentRequestDenormalizer
     /** @var TagDenormalizer */
     protected $tagDenormalizer;
 
-    public function __construct(TagDenormalizer $tagDenormalizer = null)
+    public function __construct(?TagDenormalizer $tagDenormalizer = null)
     {
         if (null === $tagDenormalizer) {
             $tagDenormalizer = new TagDenormalizer();

--- a/src/Normalizer/PaymentRequestDenormalizer.php
+++ b/src/Normalizer/PaymentRequestDenormalizer.php
@@ -16,20 +16,15 @@ namespace Jorijn\Bitcoin\Bolt11\Normalizer;
 use Jorijn\Bitcoin\Bolt11\Model\PaymentRequest;
 use Jorijn\Bitcoin\Bolt11\Model\Tag;
 
-class PaymentRequestDenormalizer
+final class PaymentRequestDenormalizer
 {
     use DenormalizerTrait;
 
-    /** @var TagDenormalizer */
-    protected $tagDenormalizer;
+    private TagDenormalizer $tagDenormalizer;
 
     public function __construct(?TagDenormalizer $tagDenormalizer = null)
     {
-        if (null === $tagDenormalizer) {
-            $tagDenormalizer = new TagDenormalizer();
-        }
-
-        $this->tagDenormalizer = $tagDenormalizer;
+        $this->tagDenormalizer = $tagDenormalizer ?? new TagDenormalizer();
     }
 
     /** @noinspection PhpIncompatibleReturnTypeInspection */

--- a/src/Normalizer/TagDenormalizer.php
+++ b/src/Normalizer/TagDenormalizer.php
@@ -23,26 +23,16 @@ class TagDenormalizer
 {
     use DenormalizerTrait;
 
-    /** @var FallbackAddressDenormalizer */
-    protected $fallbackAddressDenormalizer;
+    private FallbackAddressDenormalizer $fallbackAddressDenormalizer;
 
-    /** @var RoutingInfoDenormalizer */
-    protected $routingInfoDenormalizer;
+    private RoutingInfoDenormalizer $routingInfoDenormalizer;
 
     public function __construct(
-        FallbackAddressDenormalizer $fallbackAddressDenormalizer = null,
-        RoutingInfoDenormalizer $routingInfoDenormalizer = null
+        ?FallbackAddressDenormalizer $fallbackAddressDenormalizer = null,
+        ?RoutingInfoDenormalizer $routingInfoDenormalizer = null
     ) {
-        if (null === $fallbackAddressDenormalizer) {
-            $fallbackAddressDenormalizer = new FallbackAddressDenormalizer();
-        }
-
-        if (null === $routingInfoDenormalizer) {
-            $routingInfoDenormalizer = new RoutingInfoDenormalizer();
-        }
-
-        $this->fallbackAddressDenormalizer = $fallbackAddressDenormalizer;
-        $this->routingInfoDenormalizer = $routingInfoDenormalizer;
+        $this->fallbackAddressDenormalizer = $fallbackAddressDenormalizer ?? new FallbackAddressDenormalizer();
+        $this->routingInfoDenormalizer = $routingInfoDenormalizer ?? new RoutingInfoDenormalizer();
     }
 
     public function denormalize(array $data, $type)

--- a/tests/Encoder/PaymentRequestDecoderTest.php
+++ b/tests/Encoder/PaymentRequestDecoderTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Jorijn\Bitcoin\Bolt11\Encoder\PaymentRequestDecoder
+ *
  * @covers ::__construct
  *
  * @internal
@@ -46,14 +47,14 @@ final class PaymentRequestDecoderTest extends TestCase
      *
      * @return array[]
      */
-    public function providerOfSuccessScenarios(): array
+    public static function provideSuccessScenariosCases(): iterable
     {
         return [
             'Invoice without expiry value' => [
                 'lnbc20u1pvjluezhp58yjmdan79s6qqdhdzgynm4zwqd5d7xmw5fk98klysy043l2ahrqspp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqfppqw508d6qejxtdg4y5r3zarvary0c5xw7ksp5m6kmam774klwlh4dhmhaatd7al02m0h0m6kmam774klwlh4dhmhs9qypqqqxqrrsscqpfck3fd5pdf7ermq4ajdr7eawzxzzspr8f2fqtw8kewj5f57l4uexxwgdy3xftzqm8a0yh7rnt6wsuzay8tqauq0cufzmamfu0y8zplhqpgpuvpj',
                 [
                     'prefix' => 'lnbc20u',
-                    'expiry_timestamp' => (1496314658 + 3600)
+                    'expiry_timestamp' => (1496314658 + 3600),
                 ],
             ],
             'Please make a donation of any amount using payment_hash 0001020304050607080900010203040506070809000102030405060708090102 to me @03e7156ae33b0a208d0744199163177e909e80176e55d97a2f221ede0f934dd9ad' => [
@@ -284,7 +285,7 @@ final class PaymentRequestDecoderTest extends TestCase
      *
      * @see https://github.com/lightningnetwork/lightning-rfc/blob/master/11-payment-encoding.md#examples-of-invalid-invoices
      */
-    public function providerOfInvalidScenarios(): array
+    public static function provideInvalidScenariosCases(): iterable
     {
         return [
             'Bech32 checksum is invalid.' => [
@@ -343,14 +344,15 @@ final class PaymentRequestDecoderTest extends TestCase
      * @covers ::wordsToHex
      * @covers ::wordsToIntBE
      * @covers ::wordsToUtf8
-     * @dataProvider providerOfSuccessScenarios
+     *
+     * @dataProvider provideSuccessScenariosCases
      */
     public function testSuccessScenarios(string $invoice, array $expectedResults): void
     {
         $result = $this->decoder->decode($invoice);
 
         foreach ($expectedResults as $expectedKey => $expectedValue) {
-            static::assertArrayHasKey($expectedKey, $result);
+            self::assertArrayHasKey($expectedKey, $result);
 
             if ('tags' === $expectedKey) {
                 foreach ($expectedValue as $expectedTag => $expectedTagValue) {
@@ -363,7 +365,7 @@ final class PaymentRequestDecoderTest extends TestCase
 
                         if ($tag['tag_name'] === $expectedTag) {
                             $found = true;
-                            static::assertSame(
+                            self::assertSame(
                                 $expectedTagValue,
                                 $tag['data'],
                                 sprintf('tag "%s" does not match expected value', $expectedTag)
@@ -371,19 +373,19 @@ final class PaymentRequestDecoderTest extends TestCase
                         }
                     }
 
-                    static::assertTrue($found);
+                    self::assertTrue($found);
                 }
             } elseif (\is_array($expectedValue)) {
                 foreach ($expectedValue as $expectedSubKey => $expectedSubValue) {
-                    static::assertArrayHasKey($expectedSubKey, $expectedValue);
-                    static::assertSame(
+                    self::assertArrayHasKey($expectedSubKey, $expectedValue);
+                    self::assertSame(
                         $expectedSubValue,
                         $expectedValue[$expectedSubKey],
                         sprintf('"%s.%s" does not match expected value', $expectedKey, $expectedSubKey)
                     );
                 }
             } else {
-                static::assertSame(
+                self::assertSame(
                     $expectedValue,
                     $result[$expectedKey],
                     sprintf('"%s" does not match expected value', $expectedKey)
@@ -410,7 +412,8 @@ final class PaymentRequestDecoderTest extends TestCase
      * @covers ::wordsToHex
      * @covers ::wordsToIntBE
      * @covers ::wordsToUtf8
-     * @dataProvider providerOfInvalidScenarios
+     *
+     * @dataProvider provideInvalidScenariosCases
      */
     public function testInvalidScenarios(string $invoice, string $expectedMessage, string $expectedInstanceOf): void
     {

--- a/tests/Model/PaymentRequestTest.php
+++ b/tests/Model/PaymentRequestTest.php
@@ -42,8 +42,8 @@ final class PaymentRequestTest extends TestCase
 
         $paymentRequest->setTags([$tag1, $tag2]);
 
-        static::assertNull($paymentRequest->findTagByName('tag3'));
-        static::assertSame($tag1, $paymentRequest->findTagByName('tag1'));
-        static::assertSame($tag2, $paymentRequest->findTagByName('tag2'));
+        self::assertNull($paymentRequest->findTagByName('tag3'));
+        self::assertSame($tag1, $paymentRequest->findTagByName('tag1'));
+        self::assertSame($tag2, $paymentRequest->findTagByName('tag2'));
     }
 }

--- a/tests/Normalizer/DenormalizerTraitTest.php
+++ b/tests/Normalizer/DenormalizerTraitTest.php
@@ -39,6 +39,7 @@ final class DenormalizerTraitTest extends TestCase
 
     /**
      * @covers ::denormalizerDataWithSetters
+     *
      * @noinspection MockingMethodsCorrectnessInspection
      */
     public function testDenormalizerTraitAttributeFiller(): void
@@ -51,8 +52,8 @@ final class DenormalizerTraitTest extends TestCase
             ->getMock()
         ;
 
-        $model->expects(static::once())->method('setValueOne')->with($value1 = random_int(1000, 2000));
-        $model->expects(static::once())->method('setValueTwo')->with($value2 = random_int(1000, 2000));
+        $model->expects(self::once())->method('setValueOne')->with($value1 = random_int(1000, 2000));
+        $model->expects(self::once())->method('setValueTwo')->with($value2 = random_int(1000, 2000));
 
         $mock->denormalizerDataWithSetters(
             $model,

--- a/tests/Normalizer/FallbackAddressDenormalizerTest.php
+++ b/tests/Normalizer/FallbackAddressDenormalizerTest.php
@@ -43,8 +43,8 @@ final class FallbackAddressDenormalizerTest extends TestCase
             'addressHash' => $addressHash,
         ]);
 
-        static::assertSame($code, $fallbackAddress->getCode());
-        static::assertSame($address, $fallbackAddress->getAddress());
-        static::assertSame($addressHash, $fallbackAddress->getAddressHash());
+        self::assertSame($code, $fallbackAddress->getCode());
+        self::assertSame($address, $fallbackAddress->getAddress());
+        self::assertSame($addressHash, $fallbackAddress->getAddressHash());
     }
 }

--- a/tests/Normalizer/PaymentRequestDenormalizerTest.php
+++ b/tests/Normalizer/PaymentRequestDenormalizerTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Jorijn\Bitcoin\Bolt11\Normalizer\PaymentRequestDenormalizer
+ *
  * @covers ::__construct
  *
  * @uses \Jorijn\Bitcoin\Bolt11\Model\PaymentRequest
@@ -33,10 +34,10 @@ use PHPUnit\Framework\TestCase;
 final class PaymentRequestDenormalizerTest extends TestCase
 {
     /** @var PaymentRequestDenormalizer */
-    protected $denormalizer;
+    private $denormalizer;
 
     /** @var MockObject|TagDenormalizer */
-    protected $tagDenormalizer;
+    private $tagDenormalizer;
 
     protected function setUp(): void
     {
@@ -65,7 +66,7 @@ final class PaymentRequestDenormalizerTest extends TestCase
         ];
 
         $this->tagDenormalizer
-            ->expects(static::once())
+            ->expects(self::once())
             ->method('denormalize')
             ->with($tags, Tag::class.'[]')
             ->willReturn($denormalizedTags)
@@ -73,14 +74,14 @@ final class PaymentRequestDenormalizerTest extends TestCase
 
         $paymentRequest = $this->denormalizer->denormalize($data);
 
-        static::assertSame($prefix, $paymentRequest->getPrefix());
-        static::assertSame($network, $paymentRequest->getNetwork());
-        static::assertSame($timestamp, $paymentRequest->getTimestamp());
-        static::assertSame($timestampString, $paymentRequest->getTimestampDateTime()->format(\DateTime::ATOM));
-        static::assertSame($payeeNodeKey, $paymentRequest->getPayeeNodeKey());
-        static::assertSame($signature, $paymentRequest->getSignature());
-        static::assertSame($recoveryFlag, $paymentRequest->getRecoveryFlag());
-        static::assertSame($denormalizedTags, $paymentRequest->getTags());
+        self::assertSame($prefix, $paymentRequest->getPrefix());
+        self::assertSame($network, $paymentRequest->getNetwork());
+        self::assertSame($timestamp, $paymentRequest->getTimestamp());
+        self::assertSame($timestampString, $paymentRequest->getTimestampDateTime()->format(\DateTime::ATOM));
+        self::assertSame($payeeNodeKey, $paymentRequest->getPayeeNodeKey());
+        self::assertSame($signature, $paymentRequest->getSignature());
+        self::assertSame($recoveryFlag, $paymentRequest->getRecoveryFlag());
+        self::assertSame($denormalizedTags, $paymentRequest->getTags());
     }
 
     /**
@@ -107,24 +108,24 @@ final class PaymentRequestDenormalizerTest extends TestCase
 
         $paymentRequest = $this->denormalizer->denormalize($data);
 
-        static::assertSame($prefix, $paymentRequest->getPrefix());
-        static::assertSame($network, $paymentRequest->getNetwork());
-        static::assertSame($satoshis, $paymentRequest->getSatoshis());
-        static::assertSame($milliSatoshis, $paymentRequest->getMilliSatoshis());
-        static::assertSame($timestamp, $paymentRequest->getTimestamp());
-        static::assertSame($payeeNodeKey, $paymentRequest->getPayeeNodeKey());
-        static::assertSame($signature, $paymentRequest->getSignature());
-        static::assertSame($recoveryFlag, $paymentRequest->getRecoveryFlag());
-        static::assertSame($expiryTimestamp, $paymentRequest->getExpiryTimestamp());
+        self::assertSame($prefix, $paymentRequest->getPrefix());
+        self::assertSame($network, $paymentRequest->getNetwork());
+        self::assertSame($satoshis, $paymentRequest->getSatoshis());
+        self::assertSame($milliSatoshis, $paymentRequest->getMilliSatoshis());
+        self::assertSame($timestamp, $paymentRequest->getTimestamp());
+        self::assertSame($payeeNodeKey, $paymentRequest->getPayeeNodeKey());
+        self::assertSame($signature, $paymentRequest->getSignature());
+        self::assertSame($recoveryFlag, $paymentRequest->getRecoveryFlag());
+        self::assertSame($expiryTimestamp, $paymentRequest->getExpiryTimestamp());
 
-        static::assertSame(
+        self::assertSame(
             $timestampString,
             null !== $timestampString
                 ? $paymentRequest->getTimestampDateTime()->format(\DateTime::ATOM)
                 : $paymentRequest->getTimestampDateTime()
         );
 
-        static::assertSame(
+        self::assertSame(
             $expiryDateTime,
             null !== $expiryDateTime
                 ? $paymentRequest->getExpiryDateTime()->format(\DateTime::ATOM)

--- a/tests/Normalizer/RoutingInfoDenormalizerTest.php
+++ b/tests/Normalizer/RoutingInfoDenormalizerTest.php
@@ -53,12 +53,12 @@ final class RoutingInfoDenormalizerTest extends TestCase
             ],
         ], RoutingInfo::class.'[]');
 
-        static::assertNotEmpty($routingInfoArray);
-        static::assertSame($pubkey, $routingInfoArray[0]->getPubKey());
-        static::assertSame($shortChannelId, $routingInfoArray[0]->getShortChannelId());
-        static::assertSame($feeBaseMsat, $routingInfoArray[0]->getFeeBaseMsat());
-        static::assertSame($feeProportionalMillionths, $routingInfoArray[0]->getFeeProportionalMillionths());
-        static::assertSame($cltvExpiryDelta, $routingInfoArray[0]->getCltvExpiryDelta());
+        self::assertNotEmpty($routingInfoArray);
+        self::assertSame($pubkey, $routingInfoArray[0]->getPubKey());
+        self::assertSame($shortChannelId, $routingInfoArray[0]->getShortChannelId());
+        self::assertSame($feeBaseMsat, $routingInfoArray[0]->getFeeBaseMsat());
+        self::assertSame($feeProportionalMillionths, $routingInfoArray[0]->getFeeProportionalMillionths());
+        self::assertSame($cltvExpiryDelta, $routingInfoArray[0]->getCltvExpiryDelta());
 
         // assert single denormalize
         $routingInfo = $denormalizer->denormalize([
@@ -69,10 +69,10 @@ final class RoutingInfoDenormalizerTest extends TestCase
             'cltv_expiry_delta' => $cltvExpiryDelta,
         ], RoutingInfo::class);
 
-        static::assertSame($pubkey, $routingInfo->getPubKey());
-        static::assertSame($shortChannelId, $routingInfo->getShortChannelId());
-        static::assertSame($feeBaseMsat, $routingInfo->getFeeBaseMsat());
-        static::assertSame($feeProportionalMillionths, $routingInfo->getFeeProportionalMillionths());
-        static::assertSame($cltvExpiryDelta, $routingInfo->getCltvExpiryDelta());
+        self::assertSame($pubkey, $routingInfo->getPubKey());
+        self::assertSame($shortChannelId, $routingInfo->getShortChannelId());
+        self::assertSame($feeBaseMsat, $routingInfo->getFeeBaseMsat());
+        self::assertSame($feeProportionalMillionths, $routingInfo->getFeeProportionalMillionths());
+        self::assertSame($cltvExpiryDelta, $routingInfo->getCltvExpiryDelta());
     }
 }

--- a/tests/Normalizer/TagDenormalizerTest.php
+++ b/tests/Normalizer/TagDenormalizerTest.php
@@ -26,6 +26,7 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass \Jorijn\Bitcoin\Bolt11\Normalizer\TagDenormalizer
+ *
  * @covers ::__construct
  *
  * @uses \Jorijn\Bitcoin\Bolt11\Normalizer\DenormalizerTrait
@@ -37,13 +38,13 @@ use PHPUnit\Framework\TestCase;
 final class TagDenormalizerTest extends TestCase
 {
     /** @var FallbackAddressDenormalizer|MockObject */
-    protected $fallbackAddressDenormalizer;
+    private $fallbackAddressDenormalizer;
 
     /** @var MockObject|RoutingInfoDenormalizer */
-    protected $routingInfoDenormalizer;
+    private $routingInfoDenormalizer;
 
     /** @var TagDenormalizer */
-    protected $tagDenormalizer;
+    private $tagDenormalizer;
 
     protected function setUp(): void
     {
@@ -71,9 +72,9 @@ final class TagDenormalizerTest extends TestCase
             ],
         ], Tag::class);
 
-        static::assertInstanceOf(UnknownTag::class, $tag);
-        static::assertSame((string) $tagCode, $tag->getTagName());
-        static::assertSame($words, $tag->getData());
+        self::assertInstanceOf(UnknownTag::class, $tag);
+        self::assertSame((string) $tagCode, $tag->getTagName());
+        self::assertSame($words, $tag->getData());
     }
 
     /**
@@ -89,10 +90,10 @@ final class TagDenormalizerTest extends TestCase
             ],
         ], Tag::class.'[]');
 
-        static::assertNotEmpty($tags);
-        static::assertInstanceOf(Tag::class, $tags[0]);
-        static::assertSame($tagName, $tags[0]->getTagName());
-        static::assertSame($data, $tags[0]->getData());
+        self::assertNotEmpty($tags);
+        self::assertInstanceOf(Tag::class, $tags[0]);
+        self::assertSame($tagName, $tags[0]->getTagName());
+        self::assertSame($data, $tags[0]->getData());
     }
 
     /**
@@ -106,9 +107,9 @@ final class TagDenormalizerTest extends TestCase
             'data' => $data = 'data'.random_int(1000, 2000),
         ], Tag::class);
 
-        static::assertInstanceOf(Tag::class, $tag);
-        static::assertSame($tagName, $tag->getTagName());
-        static::assertSame($data, $tag->getData());
+        self::assertInstanceOf(Tag::class, $tag);
+        self::assertSame($tagName, $tag->getTagName());
+        self::assertSame($data, $tag->getData());
     }
 
     /**
@@ -122,7 +123,7 @@ final class TagDenormalizerTest extends TestCase
         $routingInfo2 = $this->createMock(RoutingInfo::class);
 
         $this->routingInfoDenormalizer
-            ->expects(static::once())
+            ->expects(self::once())
             ->method('denormalize')
             ->with($inputArray, RoutingInfo::class.'[]')
             ->willReturn([$routingInfo1, $routingInfo2])
@@ -133,9 +134,9 @@ final class TagDenormalizerTest extends TestCase
             'data' => $inputArray,
         ], Tag::class);
 
-        static::assertInstanceOf(Tag::class, $tag);
-        static::assertSame(Tag::ROUTING_INFO, $tag->getTagName());
-        static::assertSame([$routingInfo1, $routingInfo2], $tag->getData());
+        self::assertInstanceOf(Tag::class, $tag);
+        self::assertSame(Tag::ROUTING_INFO, $tag->getTagName());
+        self::assertSame([$routingInfo1, $routingInfo2], $tag->getData());
     }
 
     /**
@@ -148,7 +149,7 @@ final class TagDenormalizerTest extends TestCase
         $fallbackAddress = $this->createMock(FallbackAddress::class);
 
         $this->fallbackAddressDenormalizer
-            ->expects(static::once())
+            ->expects(self::once())
             ->method('denormalize')
             ->with($inputArray)
             ->willReturn($fallbackAddress)
@@ -159,8 +160,8 @@ final class TagDenormalizerTest extends TestCase
             'data' => $inputArray,
         ], Tag::class);
 
-        static::assertInstanceOf(Tag::class, $tag);
-        static::assertSame(Tag::FALLBACK_ADDRESS, $tag->getTagName());
-        static::assertSame($fallbackAddress, $tag->getData());
+        self::assertInstanceOf(Tag::class, $tag);
+        self::assertSame(Tag::FALLBACK_ADDRESS, $tag->getTagName());
+        self::assertSame($fallbackAddress, $tag->getData());
     }
 }


### PR DESCRIPTION
## Description

The v1 is deprecated. The latest stable is v4: https://github.com/actions/checkout

I simplified the `.gitignore` and adding `.idea/` and unifying all `*.cache` files/dirs

Additionally, I apply some other refactoring. No logic has been changed.